### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Audit `Cargo.lock` files for crates with security vulnerabilities reported to th
 
 ## Requirements
 
-`cargo audit` requires Rust **1.40** or later.
+`cargo audit` requires Rust **1.44** or later.
 
 ## Installation
 


### PR DESCRIPTION
cargo-audit now requires rustc 1.44 because of dependency on semver-parser, which now requires rustc 1.44. For details, see:
https://github.com/steveklabnik/semver/issues/218